### PR TITLE
CI smoke matrix for common WeasyPrint CLI versions

### DIFF
--- a/.docker/weasyprint-smoke.Dockerfile
+++ b/.docker/weasyprint-smoke.Dockerfile
@@ -1,0 +1,31 @@
+FROM node:22-bookworm-slim
+
+ARG WEASYPRINT_VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CI=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  python3 \
+  python3-pip \
+  libcairo2 \
+  libpango-1.0-0 \
+  libpangocairo-1.0-0 \
+  libgdk-pixbuf-2.0-0 \
+  libffi-dev \
+  shared-mime-info \
+  fonts-dejavu-core \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --no-cache-dir --break-system-packages --upgrade pip \
+  && python3 -m pip install --no-cache-dir --break-system-packages \
+    "weasyprint==${WEASYPRINT_VERSION}" \
+    "pydyf==0.10.0" \
+  && weasyprint --version
+
+WORKDIR /work
+
+COPY . .
+RUN npm ci
+
+CMD ["npm", "run", "test:real"]

--- a/.github/workflows/weasyprint-latest-nightly.yml
+++ b/.github/workflows/weasyprint-latest-nightly.yml
@@ -1,49 +1,13 @@
-name: CI
+name: WeasyPrint Latest
 
 on:
-  push:
-    branches:
-      - master
-      - main
-      - "codex/**"
-  pull_request:
+  schedule:
+    - cron: "0 10 * * 1"
+  workflow_dispatch:
 
 jobs:
-  test:
-    name: Node ${{ matrix.node }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [18, 20, 22]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Format check
-        run: npm run format:check
-
-      - name: Run unit + module tests
-        run: npm test
-
-      - name: Verify package contents
-        run: npm run pack:check
-
-  smoke-latest-weasyprint:
-    name: Smoke latest WeasyPrint
+  smoke-latest:
+    name: WeasyPrint latest
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/weasyprint-smoke.yml
+++ b/.github/workflows/weasyprint-smoke.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        weasyprint-version: ["53.3", "57.2", "60.2", "61.2", "62.3"]
+        weasyprint-version: ["52.5", "53.3", "57.2", "60.2", "61.2", "62.3"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/weasyprint-smoke.yml
+++ b/.github/workflows/weasyprint-smoke.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        weasyprint-version: ["53.3", "60.2", "62.3"]
+        weasyprint-version: ["53.3", "57.2", "60.2", "61.2", "62.3"]
 
     steps:
       - name: Checkout
@@ -48,7 +48,9 @@ jobs:
       - name: Install WeasyPrint CLI
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "weasyprint==${{ matrix.weasyprint-version }}"
+          python -m pip install \
+            "weasyprint==${{ matrix.weasyprint-version }}" \
+            "pydyf==0.10.0"
           weasyprint --version
           which weasyprint
 

--- a/.github/workflows/weasyprint-smoke.yml
+++ b/.github/workflows/weasyprint-smoke.yml
@@ -11,11 +11,21 @@ on:
 
 jobs:
   smoke:
+    name: WeasyPrint ${{ matrix.weasyprint-version }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        weasyprint-version: ["53.3", "60.2", "62.3"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -23,10 +33,22 @@ jobs:
           node-version: 22
           cache: npm
 
-      - name: Install WeasyPrint CLI
+      - name: Install WeasyPrint system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y weasyprint
+          sudo apt-get install -y \
+            libcairo2 \
+            libpango-1.0-0 \
+            libpangocairo-1.0-0 \
+            libgdk-pixbuf-2.0-0 \
+            libffi-dev \
+            shared-mime-info \
+            fonts-dejavu-core
+
+      - name: Install WeasyPrint CLI
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "weasyprint==${{ matrix.weasyprint-version }}"
           weasyprint --version
           which weasyprint
 
@@ -42,6 +64,6 @@ jobs:
       - name: Upload generated PDF
         uses: actions/upload-artifact@v4
         with:
-          name: smoke-pdf
+          name: smoke-pdf-weasyprint-${{ matrix.weasyprint-version }}
           path: artifacts/test-smoke.pdf
           if-no-files-found: error

--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,8 @@
 
 A Node.js wrapper around the `weasyprint` CLI.
 
+CI runs the real-world smoke test against multiple commonly used `weasyprint` releases: `53.3`, `60.2`, and `62.3`.
+
 ## Install
 
 ```bash

--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,10 @@ A Node.js wrapper around the `weasyprint` CLI.
 
 CI runs the real-world smoke test against multiple commonly used `weasyprint` releases: `52.5`, `53.3`, `57.2`, `60.2`, `61.2`, and `62.3`.
 
+Main CI (`.github/workflows/ci.yml`) also runs a latest-unpinned `weasyprint` smoke test on push/PR.
+
+A separate scheduled workflow (`.github/workflows/weasyprint-latest-nightly.yml`) runs weekly against the latest unpinned `weasyprint` release and can also be run manually from Actions.
+
 ## Install
 
 ```bash

--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@
 
 A Node.js wrapper around the `weasyprint` CLI.
 
-CI runs the real-world smoke test against multiple commonly used `weasyprint` releases: `53.3`, `60.2`, and `62.3`.
+CI runs the real-world smoke test against multiple commonly used `weasyprint` releases: `53.3`, `57.2`, `60.2`, `61.2`, and `62.3`.
 
 ## Install
 
@@ -118,6 +118,20 @@ Run:
 
 ```bash
 npm run test:real
+```
+
+### Local Docker Matrix (No Host Pollution)
+
+Run the same multi-version smoke matrix locally in Docker:
+
+```bash
+npm run test:real:docker
+```
+
+Optional: pass explicit versions:
+
+```bash
+scripts/docker-smoke-matrix.sh 53.3 57.2 60.2 61.2 62.3
 ```
 
 If your binary is not on `PATH`:

--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@
 
 A Node.js wrapper around the `weasyprint` CLI.
 
-CI runs the real-world smoke test against multiple commonly used `weasyprint` releases: `53.3`, `57.2`, `60.2`, `61.2`, and `62.3`.
+CI runs the real-world smoke test against multiple commonly used `weasyprint` releases: `52.5`, `53.3`, `57.2`, `60.2`, `61.2`, and `62.3`.
 
 ## Install
 
@@ -131,7 +131,7 @@ npm run test:real:docker
 Optional: pass explicit versions:
 
 ```bash
-scripts/docker-smoke-matrix.sh 53.3 57.2 60.2 61.2 62.3
+scripts/docker-smoke-matrix.sh 52.5 53.3 57.2 60.2 61.2 62.3
 ```
 
 If your binary is not on `PATH`:

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "prepack": "npm run build",
     "test": "npm run build && node test/index.test.js && node test/esm.test.mjs",
     "test:real": "npm run build && node scripts/real-world-smoke.js",
+    "test:real:docker": "scripts/docker-smoke-matrix.sh",
     "smoke:pdf": "npm run build && node scripts/generate-test-pdf.js"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weasyprint-wrapper",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Node.js wrapper around the WeasyPrint CLI",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/scripts/docker-smoke-matrix.sh
+++ b/scripts/docker-smoke-matrix.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOCKERFILE_PATH="${ROOT_DIR}/.docker/weasyprint-smoke.Dockerfile"
+IMAGE_NAME="weasyprint-wrapper-smoke"
+
+if [[ $# -gt 0 ]]; then
+  VERSIONS=("$@")
+else
+  VERSIONS=("53.3" "57.2" "60.2" "61.2" "62.3")
+fi
+
+failures=0
+
+echo "Running WeasyPrint smoke matrix in Docker"
+echo "Versions: ${VERSIONS[*]}"
+
+for version in "${VERSIONS[@]}"; do
+  image_tag="${IMAGE_NAME}:${version}"
+  echo
+  echo "=== [${version}] build image ==="
+
+  if ! docker build \
+    --file "${DOCKERFILE_PATH}" \
+    --build-arg "WEASYPRINT_VERSION=${version}" \
+    --tag "${image_tag}" \
+    "${ROOT_DIR}"; then
+    echo "FAIL [${version}] docker build"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  echo "=== [${version}] run smoke test ==="
+  if ! docker run --rm "${image_tag}"; then
+    echo "FAIL [${version}] smoke test"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  echo "PASS [${version}]"
+done
+
+echo
+if [[ ${failures} -gt 0 ]]; then
+  echo "Matrix completed with ${failures} failing version(s)"
+  exit 1
+fi
+
+echo "Matrix completed successfully"

--- a/scripts/docker-smoke-matrix.sh
+++ b/scripts/docker-smoke-matrix.sh
@@ -8,7 +8,7 @@ IMAGE_NAME="weasyprint-wrapper-smoke"
 if [[ $# -gt 0 ]]; then
   VERSIONS=("$@")
 else
-  VERSIONS=("53.3" "57.2" "60.2" "61.2" "62.3")
+  VERSIONS=("52.5" "53.3" "57.2" "60.2" "61.2" "62.3")
 fi
 
 failures=0

--- a/src/core.js
+++ b/src/core.js
@@ -70,7 +70,13 @@ function buildOptionArgs(options) {
   return args;
 }
 
-function buildArgsAndInput(input, options) {
+function hasExplicitFormat(options) {
+  return [options.f, options.format].some(
+    (value) => value !== undefined && value !== null && value !== false
+  );
+}
+
+function buildArgsAndInput(input, options, compat = {}) {
   const output = options.output;
   const optionArgs = buildOptionArgs(options);
   const inputMode = getInputMode(input);
@@ -81,6 +87,12 @@ function buildArgsAndInput(input, options) {
 
   const inputArg = inputMode === "url" ? input.trim() : "-";
   const outputArg = output ? String(output) : "-";
+  const needsStdoutFormat =
+    compat.forceStdoutPdfFormat === true && outputArg === "-" && !hasExplicitFormat(options);
+
+  if (needsStdoutFormat) {
+    optionArgs.push("-f", "pdf");
+  }
 
   return {
     args: [...optionArgs, inputArg, outputArg],
@@ -105,6 +117,16 @@ function createExitError(code, signal, stderr) {
   return err;
 }
 
+function probeSupportsStdoutFormatFlag(command) {
+  const probe = spawnSync(command, ["--help"], { encoding: "utf8" });
+  if (probe.error || probe.status !== 0) {
+    return false;
+  }
+
+  const helpText = `${probe.stdout || ""}\n${probe.stderr || ""}`;
+  return /(^|\s)-f(\s|,|$)/.test(helpText);
+}
+
 function createWeasyprint(defaultSpawn) {
   function weasyprint(input, options, callback) {
     if (typeof options === "function") {
@@ -113,9 +135,30 @@ function createWeasyprint(defaultSpawn) {
     }
 
     const normalizedOptions = normalizeOptions(options);
-    const { args, inputMode } = buildArgsAndInput(input, normalizedOptions);
-
     const spawnImpl = weasyprint._spawn || defaultSpawn;
+    let forceStdoutPdfFormat = false;
+    const shouldProbe =
+      spawnImpl === defaultSpawn &&
+      !hasExplicitFormat(normalizedOptions) &&
+      !normalizedOptions.output;
+
+    if (shouldProbe) {
+      if (
+        !weasyprint._stdoutFormatFlagProbe ||
+        weasyprint._stdoutFormatFlagProbe.command !== weasyprint.command
+      ) {
+        weasyprint._stdoutFormatFlagProbe = {
+          command: weasyprint.command,
+          supported: probeSupportsStdoutFormatFlag(weasyprint.command),
+        };
+      }
+
+      forceStdoutPdfFormat = weasyprint._stdoutFormatFlagProbe.supported;
+    }
+
+    const { args, inputMode } = buildArgsAndInput(input, normalizedOptions, {
+      forceStdoutPdfFormat,
+    });
     const child = spawnImpl(weasyprint.command, args, {
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -166,14 +209,18 @@ function createWeasyprint(defaultSpawn) {
 
   weasyprint.command = "weasyprint";
   weasyprint._spawn = null;
+  weasyprint._stdoutFormatFlagProbe = null;
   weasyprint._internals = {
     buildOptionArgs,
     buildArgsAndInput,
+    hasExplicitFormat,
     getInputMode,
     isUrl,
+    probeSupportsStdoutFormatFlag,
   };
 
   return weasyprint;
 }
 
 module.exports = createWeasyprint;
+const { spawnSync } = require("child_process");

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -128,5 +128,23 @@ async function run(name, fn) {
     assert.strictEqual(spawnCalled, false);
   });
 
+  await run("supports forcing stdout format flag for legacy cli", () => {
+    const forced = weasyprint._internals.buildArgsAndInput(
+      "<h1>Hi</h1>",
+      {},
+      {
+        forceStdoutPdfFormat: true,
+      }
+    );
+    assert.deepStrictEqual(forced.args, ["-f", "pdf", "-", "-"]);
+
+    const explicit = weasyprint._internals.buildArgsAndInput(
+      "<h1>Hi</h1>",
+      { f: "png" },
+      { forceStdoutPdfFormat: true }
+    );
+    assert.deepStrictEqual(explicit.args, ["-f", "png", "-", "-"]);
+  });
+
   weasyprint._spawn = null;
 })();


### PR DESCRIPTION
## Summary
- Strengthen integration coverage for this wrapper across pinned and latest WeasyPrint CLI versions.
- Add compatibility handling so legacy and modern WeasyPrint CLIs both work with stdout output mode.

## What Changed
- Added Docker-based local smoke matrix harness:
  - `.docker/weasyprint-smoke.Dockerfile`
  - `scripts/docker-smoke-matrix.sh`
  - `package.json` script: `test:real:docker`
- Expanded pinned smoke matrix in `.github/workflows/weasyprint-smoke.yml`:
  - `52.5`, `53.3`, `57.2`, `60.2`, `61.2`, `62.3`
  - pinned `pydyf==0.10.0` to avoid upstream transitive breakage
- Added compatibility logic in `src/core.js`:
  - detects CLI support via `weasyprint --help`
  - adds `-f pdf` only when required/supported for stdout mode
- Added/updated tests in `test/index.test.js` for legacy format-flag behavior.
- Added latest-unpinned smoke coverage:
  - push/PR job in `.github/workflows/ci.yml`
  - scheduled/manual latest workflow `.github/workflows/weasyprint-latest-nightly.yml`
- Updated README for matrix coverage and latest smoke workflows.

## Validation
- `npm test`
- `npm run test:real:docker`

## Scope Notes
- Current branch already contains commits:
  - `0d0a64c` `ci(smoke): add docker matrix and broaden weasyprint coverage`
  - `a4f7595` `fix(smoke): support legacy weasyprint stdout format behavior`
  - `bca4665` `add latest version CI tests`
- Current working tree has an unstaged version bump in `package.json` (`1.0.0` -> `1.0.1`).
