### PR TITLE
Update WeasyPrint smoke test versions

### DIFF
--- a/.docker/weasyprint-smoke.Dockerfile
+++ b/.docker/weasyprint-smoke.Dockerfile
@@ -1,6 +1,7 @@
 FROM node:22-bookworm-slim
 
 ARG WEASYPRINT_VERSION
+ARG PYDYF_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CI=1
@@ -18,9 +19,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install --no-cache-dir --break-system-packages --upgrade pip \
-  && python3 -m pip install --no-cache-dir --break-system-packages \
-    "weasyprint==${WEASYPRINT_VERSION}" \
-    "pydyf==0.10.0" \
+  && if [ -n "${PYDYF_VERSION}" ]; then \
+    python3 -m pip install --no-cache-dir --break-system-packages \
+      "weasyprint==${WEASYPRINT_VERSION}" \
+      "pydyf==${PYDYF_VERSION}"; \
+  else \
+    python3 -m pip install --no-cache-dir --break-system-packages \
+      "weasyprint==${WEASYPRINT_VERSION}"; \
+  fi \
   && weasyprint --version
 
 WORKDIR /work

--- a/.github/workflows/weasyprint-smoke.yml
+++ b/.github/workflows/weasyprint-smoke.yml
@@ -16,7 +16,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        weasyprint-version: ["52.5", "53.3", "57.2", "60.2", "61.2", "62.3"]
+        include:
+          - weasyprint-version: "52.5"
+            pydyf-version: "0.10.0"
+          - weasyprint-version: "53.3"
+            pydyf-version: "0.10.0"
+          - weasyprint-version: "57.2"
+            pydyf-version: "0.10.0"
+          - weasyprint-version: "60.2"
+            pydyf-version: "0.10.0"
+          - weasyprint-version: "61.2"
+            pydyf-version: "0.10.0"
+          - weasyprint-version: "62.3"
+            pydyf-version: "0.10.0"
+          - weasyprint-version: "65.1"
+          - weasyprint-version: "66.0"
+          - weasyprint-version: "67.0"
+          - weasyprint-version: "68.1"
+          - weasyprint-version: "69.0"
 
     steps:
       - name: Checkout
@@ -48,9 +65,14 @@ jobs:
       - name: Install WeasyPrint CLI
         run: |
           python -m pip install --upgrade pip
-          python -m pip install \
-            "weasyprint==${{ matrix.weasyprint-version }}" \
-            "pydyf==0.10.0"
+          if [ -n "${{ matrix.pydyf-version }}" ]; then
+            python -m pip install \
+              "weasyprint==${{ matrix.weasyprint-version }}" \
+              "pydyf==${{ matrix.pydyf-version }}"
+          else
+            python -m pip install \
+              "weasyprint==${{ matrix.weasyprint-version }}"
+          fi
           weasyprint --version
           which weasyprint
 

--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@
 
 A Node.js wrapper around the `weasyprint` CLI.
 
-CI runs the real-world smoke test against multiple commonly used `weasyprint` releases: `52.5`, `53.3`, `57.2`, `60.2`, `61.2`, and `62.3`.
+CI runs the real-world smoke test against multiple commonly used `weasyprint` releases: `52.5`, `53.3`, `57.2`, `60.2`, `61.2`, `62.3`, `65.1`, `66.0`, `67.0`, `68.1`, and `69.0`.
 
 Main CI (`.github/workflows/ci.yml`) also runs a latest-unpinned `weasyprint` smoke test on push/PR.
 
@@ -136,7 +136,7 @@ npm run test:real:docker
 Optional: pass explicit versions:
 
 ```bash
-scripts/docker-smoke-matrix.sh 52.5 53.3 57.2 60.2 61.2 62.3
+scripts/docker-smoke-matrix.sh 52.5 53.3 57.2 60.2 61.2 62.3 65.1 66.0 67.0 68.1 69.0
 ```
 
 If your binary is not on `PATH`:

--- a/scripts/docker-smoke-matrix.sh
+++ b/scripts/docker-smoke-matrix.sh
@@ -8,7 +8,7 @@ IMAGE_NAME="weasyprint-wrapper-smoke"
 if [[ $# -gt 0 ]]; then
   VERSIONS=("$@")
 else
-  VERSIONS=("52.5" "53.3" "57.2" "60.2" "61.2" "62.3")
+  VERSIONS=("52.5" "53.3" "57.2" "60.2" "61.2" "62.3" "65.1" "66.0" "67.0" "68.1" "69.0")
 fi
 
 failures=0
@@ -18,12 +18,18 @@ echo "Versions: ${VERSIONS[*]}"
 
 for version in "${VERSIONS[@]}"; do
   image_tag="${IMAGE_NAME}:${version}"
+  pydyf_version=""
+  case "${version}" in
+    5[2-9].* | 6[0-4].*) pydyf_version="0.10.0" ;;
+  esac
+
   echo
   echo "=== [${version}] build image ==="
 
   if ! docker build \
     --file "${DOCKERFILE_PATH}" \
     --build-arg "WEASYPRINT_VERSION=${version}" \
+    --build-arg "PYDYF_VERSION=${pydyf_version}" \
     --tag "${image_tag}" \
     "${ROOT_DIR}"; then
     echo "FAIL [${version}] docker build"


### PR DESCRIPTION
## Summary
- Expand the WeasyPrint smoke test matrix to cover newer released versions through `69.0`.

## What Changed
- Added WeasyPrint `65.1`, `66.0`, `67.0`, `68.1`, and `69.0` to the GitHub Actions smoke matrix.
- Updated the local Docker smoke matrix defaults to match CI.
- Made the Docker smoke installer pin `pydyf==0.10.0` only for legacy WeasyPrint versions while letting newer versions resolve their required dependency.
- Updated README smoke test version documentation and the explicit Docker matrix example.

## Validation
- `bash -n scripts/docker-smoke-matrix.sh`
- `npm run format:check`
- `npm test`

## Scope Notes
- Full Docker smoke matrix was not run locally because it builds 11 images and fetches apt/PyPI dependencies.